### PR TITLE
Enable binder and ashmem modules

### DIFF
--- a/config
+++ b/config
@@ -8899,6 +8899,12 @@ CONFIG_ASYNC_RAID6_TEST=m
 # end of Kernel Testing and Coverage
 # end of Kernel hacking
 
+# Enable ashmem and binder modules
+CONFIG_ASHMEM=y
+CONFIG_ANDROID=y
+CONFIG_ANDROID_BINDER_IPC=y
+CONFIG_ANDROID_BINDERFS=y
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"
 
 # kernel-config sources:
 # FILEVER=/usr/share/kernel-config/base-5.7-4-44


### PR DESCRIPTION
Anbox is a free and open-source compatibility layer that aims to allow mobile applications and mobile games developed for Android to run on GNU/Linux distributions.
The application needs binder and ashmem modules to work. The project used to provide dkms modules alongside the application itself. The dkms modules, however, are not compatible with kernel versions 5.7.0+. So to be able to use anbox one needs to compile the modules which exist in kernel tree.
It's seems a good idea to compile the modules for 5.7.0+ kernels.